### PR TITLE
Add Profile page

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { Login } from './pages/Login/index.js';
 import { Chat } from './pages/Chat';
+import { Profile } from './pages/Profile';
 
 import { startMirage } from './mocks/miragejs/index.js';
 
@@ -30,6 +31,10 @@ const router = createBrowserRouter([
   {
     path: "/chat",
     element: <Chat />,
+  },
+  {
+    path: "/profile",
+    element: <Profile />,
   }
 ]);
 

--- a/src/pages/Profile/constants/index.ts
+++ b/src/pages/Profile/constants/index.ts
@@ -1,0 +1,6 @@
+export const USERS_COLLECTION_NAME = 'profile-users';
+export const CONTACTS_COLLECTION_NAME = 'profile-contacts';
+export const MESSAGE_COLLECTION_NAME = 'profile-messages';
+
+// Final url:  chat/userId/contacts
+// Final url:  chat/userId/contacts/contactId/messages

--- a/src/pages/Profile/hooks/index.ts
+++ b/src/pages/Profile/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-hook-sample';

--- a/src/pages/Profile/hooks/use-hook-sample.tsx
+++ b/src/pages/Profile/hooks/use-hook-sample.tsx
@@ -1,0 +1,39 @@
+
+import { useEffect } from "react";
+import { EActionType } from "../../../store/flux";
+import { useStoreHook } from "../../../store/hooks/use-store";
+import { SWApiPeopleService } from '../../../services/swapi/people/index';
+import { PeopleModel } from "../../../models";
+import { useQuery } from "@tanstack/react-query";
+
+
+export const useHookSample = () => {
+  const useStore = useStoreHook((state: any) => state);
+  const swApiPeopleService =  new SWApiPeopleService();
+  const {
+    dispatch, 
+    theme
+  } = useStore;
+
+  async function fetchPeople() {
+    return await swApiPeopleService.getPeople()
+    .then((data : PeopleModel[]) => {
+      return data as PeopleModel[];
+    }).catch((error) => console.error('subscribeSample : ', error));    
+  };
+
+  const peopleQuery = useQuery({
+    queryKey: ['people'],
+    queryFn: async () => {
+      const data = await fetchPeople();
+      console.log('React query sample: ', data);
+      return data;
+    },
+  });
+
+  return {
+    peopleQuery, 
+    theme,
+    dispatch
+  }
+}

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -1,0 +1,91 @@
+import { ArrowLineLeft } from '@phosphor-icons/react';
+
+import { Footer } from '../../commons/components/Footer';
+import { useHookSample } from './hooks';
+import { EScreenState } from '../../enums';
+import { ErrorApiComponent, LoadingComponent, NoContentComponent } from '../../commons/components/ApiFeedbacks';
+import { stateKey } from '../../commons/utils/renders/screent-type';
+
+export const Profile = () => {
+
+
+  const useHook = useHookSample();
+  const { peopleQuery, theme } = useHook;
+  const {    
+    data: people,    
+    refetch,    
+   } = peopleQuery;
+
+  const hasSelectedContact = false;
+  const containerClasses = {
+    'mobile': 'min-[0px]:block',
+    'default': 'min-[690px]:flex flex'
+  };
+
+  const messagesContainerClasses = {
+    'mobile': !hasSelectedContact ? 'none' : 'min-[0px]:w-full',
+    'default': 'max=[600px]:flex-1 w-full'
+  };
+
+  const isMobile = () => {
+    return window.screen.width <= 690;
+  }
+
+  const screnType = isMobile() ? 'mobile' : 'default';
+
+  const SuccesComponent = () => (
+    <>
+      <h1>
+        Profile page
+      </h1>
+      <h1>
+        Api : Response
+        <br />
+        count: {people?.length}
+        <br />
+        Name: {people != null ? people[0].name : ''}
+      </h1>
+    </>);
+
+ 
+  const screenState : any = { 
+    [EScreenState.loading]: { render: () => <LoadingComponent /> },
+    [EScreenState.error]: { render: () => <ErrorApiComponent onRetry={refetch} /> },
+    [EScreenState.noCotent]: { render: () => <NoContentComponent /> },
+    [EScreenState.success]: { render: () => <SuccesComponent /> },
+  }; 
+  return (
+    <>
+      <div className={`w-full h-40 bg-gradient-to-r ${theme.styles.gradient}`} >
+        <ArrowLineLeft size={48} className={`mx-2 py-2 cursor-pointer ${hasSelectedContact ? 'block' : 'hidden'}`} />
+      </div>
+
+      <div className="container mx-auto mt-[-128px] rounded-sm">
+        <div className="py-6 h-screen">
+          <div className={`flex shadow-lg rounded h-full ${containerClasses[screnType]}`}>
+            {/* Left */}
+            {
+              !hasSelectedContact && (
+                <>
+                  <h1>
+                    Welcome to your profile!
+                    Request sample result on right!
+                  </h1>
+                  <Footer />
+                </>
+              )
+            }
+
+            {/* Right */}
+            <div className={`animate-[wiggle_1s_ease-in-out_infinite] shadow-sm flex flex-col ${messagesContainerClasses[screnType]}`}>
+              {screenState[`${stateKey(peopleQuery)}`]?.render() ?? LoadingComponent() }
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Profile;
+


### PR DESCRIPTION
## Summary
- create Profile page based on Chat page
- add fetch hook and constants
- register Profile route in router

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6857b159c0d08330ac9bbce1cfabef2b